### PR TITLE
fixed t8 flashcard front showing when turned around on firefox

### DIFF
--- a/app/features/flashCards/flashCardFront.tsx
+++ b/app/features/flashCards/flashCardFront.tsx
@@ -4,40 +4,60 @@ import { type Move, type MoveT8 } from '~/types/Move'
 import { charIdFromMove } from '~/utils/moveUtils'
 import { ShowVideoButton } from './showVideoButton'
 
+
 export type FlashCardFrontProps = {
   move: Move
   showCharName: boolean
   onFlip: () => void
 }
+
+export var toggled: boolean
+
+export function toggleFrontCard(): void {
+  if (toggled) {
+    toggled = false;
+  }
+  else {
+    toggled = true;
+  }
+};
 export const FlashCardFront = ({
   move,
   showCharName,
   onFlip,
 }: FlashCardFrontProps) => {
+  if (!toggled) {
+    return (
+      <div className="flex h-full w-full flex-col bg-foreground/10">
+        <button
+          type="button"
+          className="flex w-full flex-grow items-center justify-center p-2 text-xl"
+          onClick={onFlip}
+        >
+          {showCharName && `${charIdFromMove(move as MoveT8)} `}
+          {move.command}
+        </button>
+        <ShowVideoButton
+          move={move} className="m-1 my-3" hideFrameData />
+        <button
+          className="flex w-full items-center justify-center p-2 text-lg"
+          onClick={onFlip}
+        >
+          <div
+            className={cx(
+              buttonVariants({ variant: 'default' }),
+              'mt-auto h-12 w-24',
+            )}
+          >
+            Flip
+          </div>
+        </button>
+      </div>
+    );
+  }
   return (
     <div className="flex h-full w-full flex-col bg-foreground/10">
-      <button
-        type="button"
-        className="flex w-full flex-grow items-center justify-center p-2 text-xl"
-        onClick={onFlip}
-      >
-        {showCharName && `${charIdFromMove(move as MoveT8)} `}
-        {move.command}
-      </button>
-      <ShowVideoButton move={move} className="m-1 my-3" hideFrameData />
-      <button
-        className="flex w-full items-center justify-center p-2 text-lg"
-        onClick={onFlip}
-      >
-        <div
-          className={cx(
-            buttonVariants({ variant: 'default' }),
-            'mt-auto h-12 w-24',
-          )}
-        >
-          Flip
-        </div>
-      </button>
+
     </div>
-  )
+  );
 }

--- a/app/features/flashCards/flashCardFront.tsx
+++ b/app/features/flashCards/flashCardFront.tsx
@@ -4,7 +4,6 @@ import { type Move, type MoveT8 } from '~/types/Move'
 import { charIdFromMove } from '~/utils/moveUtils'
 import { ShowVideoButton } from './showVideoButton'
 
-
 export type FlashCardFrontProps = {
   move: Move
   showCharName: boolean
@@ -15,12 +14,11 @@ export var toggled: boolean
 
 export function toggleFrontCard(): void {
   if (toggled) {
-    toggled = false;
+    toggled = false
+  } else {
+    toggled = true
   }
-  else {
-    toggled = true;
-  }
-};
+}
 export const FlashCardFront = ({
   move,
   showCharName,
@@ -37,8 +35,7 @@ export const FlashCardFront = ({
           {showCharName && `${charIdFromMove(move as MoveT8)} `}
           {move.command}
         </button>
-        <ShowVideoButton
-          move={move} className="m-1 my-3" hideFrameData />
+        <ShowVideoButton move={move} className="m-1 my-3" hideFrameData />
         <button
           className="flex w-full items-center justify-center p-2 text-lg"
           onClick={onFlip}
@@ -53,11 +50,7 @@ export const FlashCardFront = ({
           </div>
         </button>
       </div>
-    );
+    )
   }
-  return (
-    <div className="flex h-full w-full flex-col bg-foreground/10">
-
-    </div>
-  );
+  return <div className="flex h-full w-full flex-col bg-foreground/10"></div>
 }

--- a/app/routes/_mainLayout.t8_.$character.flashcard.tsx
+++ b/app/routes/_mainLayout.t8_.$character.flashcard.tsx
@@ -14,7 +14,7 @@ import {
   type FlashCardAnswerType,
 } from '~/features/flashCards/FlashCardAnswer'
 import { FlashCardBack } from '~/features/flashCards/flashCardBack'
-import { FlashCardFront } from '~/features/flashCards/flashCardFront'
+import { FlashCardFront, hideVideo, toggleFrontCard } from '~/features/flashCards/flashCardFront'
 import { useFlashCardAppState } from '~/features/flashCards/useFlashCardAppState'
 import { useFrameData } from '~/hooks/useFrameData'
 import { characterGuideAuthors } from '~/services/staticDataService'
@@ -23,6 +23,7 @@ import { type Move } from '~/types/Move'
 import type { RouteHandle } from '~/types/RouteHandle'
 import { generateMetaTags } from '~/utils/seoUtils'
 import { t8AvatarMap } from '~/utils/t8AvatarMap'
+import { ShowVideoButton } from '~/features/flashCards/showVideoButton'
 
 const navData: NavLinkInfo[] = [
   { link: '../', displayName: 'Frame data' },
@@ -413,6 +414,7 @@ const FlashCardGame = ({
 
   const handleAnswer = (answer: FlashCardAnswerType) => {
     setFlipped(false)
+    toggleFrontCard();
     onAnswer(answer)
   }
 
@@ -432,7 +434,10 @@ const FlashCardGame = ({
             <FlashCardFront
               move={moveToShow}
               showCharName={showCharName}
-              onFlip={() => setFlipped(true)}
+              onFlip={() => {
+                toggleFrontCard();
+                setFlipped(true);
+              }}
             />
           </div>
           <div className="col-start-1 row-start-1 [backface-visibility:hidden] [transform:rotateY(180deg)]">

--- a/app/routes/_mainLayout.t8_.$character.flashcard.tsx
+++ b/app/routes/_mainLayout.t8_.$character.flashcard.tsx
@@ -14,7 +14,7 @@ import {
   type FlashCardAnswerType,
 } from '~/features/flashCards/FlashCardAnswer'
 import { FlashCardBack } from '~/features/flashCards/flashCardBack'
-import { FlashCardFront, hideVideo, toggleFrontCard } from '~/features/flashCards/flashCardFront'
+import { FlashCardFront, toggleFrontCard } from '~/features/flashCards/flashCardFront'
 import { useFlashCardAppState } from '~/features/flashCards/useFlashCardAppState'
 import { useFrameData } from '~/hooks/useFrameData'
 import { characterGuideAuthors } from '~/services/staticDataService'
@@ -23,7 +23,6 @@ import { type Move } from '~/types/Move'
 import type { RouteHandle } from '~/types/RouteHandle'
 import { generateMetaTags } from '~/utils/seoUtils'
 import { t8AvatarMap } from '~/utils/t8AvatarMap'
-import { ShowVideoButton } from '~/features/flashCards/showVideoButton'
 
 const navData: NavLinkInfo[] = [
   { link: '../', displayName: 'Frame data' },


### PR DESCRIPTION
Firefox was showing the front side of the flashcard when turned around so i made the front disappear when the card is turned around. only effects firefox.
Before/After in image
![image_2025-01-13_020219027](https://github.com/user-attachments/assets/d48229d5-4f26-4947-81e8-42976985135c)
 