### PR TITLE
Add total frames to move data and display

### DIFF
--- a/app/constants/sortOptions.ts
+++ b/app/constants/sortOptions.ts
@@ -83,6 +83,20 @@ export const sortOptions: {
     }),
   },
   {
+    displayName: 'Total frames (low - high)',
+    value: getSortByQueryParamValue({
+      sortByKey: 'totalFrames',
+      sortDirection: 'desc',
+    }),
+  },
+  {
+    displayName: 'Total frames (high - low)',
+    value: getSortByQueryParamValue({
+      sortByKey: 'totalFrames',
+      sortDirection: 'asc',
+    }),
+  },
+  {
     displayName: 'Interruptible (low - high)',
     value: getSortByQueryParamValue({
       sortByKey: 'interruptible',

--- a/app/features/frameQuiz/components/MoveDetailsPanel.tsx
+++ b/app/features/frameQuiz/components/MoveDetailsPanel.tsx
@@ -41,6 +41,9 @@ export const MoveDetailsPanel = ({
         <div className="text-muted-foreground">Recovery</div>
         <div className="font-medium">{formatRecovery(move) || 'N/A'}</div>
 
+        <div className="text-muted-foreground">Total frames</div>
+        <div className="font-medium">{move.totalFrames || 'N/A'}</div>
+
         <div className="text-muted-foreground">Properties</div>
         <div className="flex flex-wrap items-center gap-1.5">
           <MovePropertyIconList move={move} size="small" />

--- a/app/routes/_mainLayout.t8_.$character.$move.tsx
+++ b/app/routes/_mainLayout.t8_.$character.$move.tsx
@@ -183,6 +183,10 @@ export default function MoveRoute() {
             <Table.Cell>{move.recoveryState || 'N/A'}</Table.Cell>
           </Table.Row>
           <Table.Row>
+            <Table.RowHeaderCell>Total frames</Table.RowHeaderCell>
+            <Table.Cell>{move.totalFrames || 'N/A'}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
             <Table.RowHeaderCell>Notes</Table.RowHeaderCell>
             <Table.Cell>
               {move.notes?.split('\n').map((line, index) => (

--- a/app/types/Move.ts
+++ b/app/types/Move.ts
@@ -17,6 +17,7 @@ export type Move = {
   video?: string;
   recovery?: string;
   recoveryState?: string;
+  totalFrames?: string;
   characterId?: string;
 };
 

--- a/app/utils/frameDataUtils.ts
+++ b/app/utils/frameDataUtils.ts
@@ -46,6 +46,7 @@ export const frameDataTableToJson = (normalFrameData: TableData): Move[] => {
   const nameIndex = lowerCaseHeaders.indexOf('name');
   const recoveryIndex = lowerCaseHeaders.indexOf('recovery');
   const recoveryStateIndex = lowerCaseHeaders.indexOf('recovery state');
+  const totalFramesIndex = lowerCaseHeaders.indexOf('total frames');
   const characterIdIndex = lowerCaseHeaders.indexOf('character id');
 
   // check optional columns
@@ -76,6 +77,8 @@ export const frameDataTableToJson = (normalFrameData: TableData): Move[] => {
       recovery: row[recoveryIndex],
       recoveryState:
         recoveryStateIndex >= 0 ? row[recoveryStateIndex] : undefined,
+      totalFrames:
+        totalFramesIndex >= 0 ? row[totalFramesIndex] : undefined,
       characterId: characterIdIndex >= 0 ? row[characterIdIndex] : undefined,
     };
   });
@@ -725,6 +728,13 @@ export const sortMovesV2 = (
     }
     case 'recovery': {
       return sortMovesByNumber(moves, (move: Move) => move.recovery || '', asc);
+    }
+    case 'totalFrames': {
+      return sortMovesByNumber(
+        moves,
+        (move: Move) => move.totalFrames || '',
+        asc,
+      );
     }
     case 'interruptible': {
       return sortMovesByNumber(

--- a/utils/wavuJsonToCsv.py
+++ b/utils/wavuJsonToCsv.py
@@ -25,6 +25,7 @@ columns = [
     {"wavuId": "name", "displayName": "Name"},
     {"wavuId": "recovery_frames", "displayName": "Recovery"}, # split out of the recv field of wavu by wavuParsing
     {"wavuId": "recovery_state", "displayName": "Recovery state"}, # split out of the recv field of wavu by wavuParsing
+    {"wavuId": "tot", "displayName": "Total frames"},
     {"wavuId": "image", "displayName": "Image"},
     {"wavuId": "video", "displayName": "Video"},
     {"wavuId": "id", "displayName": "Wavu id"},


### PR DESCRIPTION
Wavu's "tot" field (startup + active + recovery frames) was already fetched and stored by the importer, but wavuJsonToCsv.py never wrote it to the CSV that feeds the site. Add a "Total frames" column and show it next to recovery frames on the move detail page and frame quiz panel.

Fixes #584